### PR TITLE
implementing new mase features 

### DIFF
--- a/R/MAest.pbar.R
+++ b/R/MAest.pbar.R
@@ -123,7 +123,13 @@ MAest.greg <- function(y,
   NBRPLT <- length(y)
   NBRPLT.gt0 <- sum(y > 0)
   
-  predselect <- x_pop[FALSE, , drop=FALSE]
+  # it's possible that too many predictors are selected when model selection was done
+  # and when estimating on a subset of sample data we have fewer plots than predictors...
+  if (length(y) <= ncol(x_sample)) {
+    x_sample <- x_sample[ , 1:(length(y) - 1), drop = F]
+    x_pop <- x_pop[ , names(x_sample), drop = F]
+  }
+  
   
   estgreg <- tryCatch(mase::greg(y = y,
                                  xsample = x_sample,

--- a/R/MAest.pbar.R
+++ b/R/MAest.pbar.R
@@ -1,26 +1,30 @@
 #' @rdname estimation_desc
 #' @export
-MAest.ht <- function(y, N, FIA=TRUE, getweights=FALSE, var_method = "LinHTSRS") {
-
+MAest.ht <- function(y,
+                     N,
+                     FIA = TRUE,
+                     getweights = FALSE,
+                     var_method = "LinHTSRS") {
+  
   ## Set global variables
   nhat.var <- NULL
-
   NBRPLT <- length(y)
   NBRPLT.gt0 <- sum(y > 0)
-  # var_method <- "LinHTSRS"
-  estht <- suppressMessages(mase::horvitzThompson(y, pi = NULL, N = N, pi2 = NULL,
-						var_est = TRUE, var_method = var_method,
-						B = 1000))
-
+  
+  estht <- mase::horvitzThompson(y,
+                                 pi = NULL,
+                                 N = N,
+                                 pi2 = NULL,
+                                 var_est = TRUE,
+                                 var_method = var_method,
+                                 messages = F,
+                                 fpc = !FIA,
+                                 B = 1000)
+  
   esthtdt <- data.table(estht$pop_mean, estht$pop_mean_var, NBRPLT, NBRPLT.gt0)
   setnames(esthtdt, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
   returnlst <- list(est=esthtdt)
-
-  if (FIA) {
-    ## This takes out the finite population correction term (to estimated variance from FIA)
-    esthtdt[, nhat.var := nhat.var / (1 - length(y) / N)]
-  }
-
+  
   ## Return survey weights
   if (getweights) {
     if (any(estht$weights < 0)) {
@@ -33,31 +37,41 @@ MAest.ht <- function(y, N, FIA=TRUE, getweights=FALSE, var_method = "LinHTSRS") 
 
 #' @rdname estimation_desc
 #' @export
-MAest.ps <- function(y, N, x_sample, x_pop, FIA=TRUE, save4testing=TRUE, getweights=FALSE,
+MAest.ps <- function(y,
+                     N,
+                     x_sample,
+                     x_pop,
+                     FIA = TRUE,
+                     save4testing = TRUE,
+                     getweights = FALSE,
                      var_method = "SRSunconditional") {
-
+  
   ## Set global variables
   nhat.var <- NULL
-
   NBRPLT <- length(y)
   NBRPLT.gt0 <- sum(y > 0)
-  # var_method <- "SRSunconditional"
-
-  estps <- tryCatch(suppressMessages(mase::postStrat(	  y = y,
-					   xsample = x_sample,
-					   xpop = x_pop,
-					   pi = NULL, N = N, pi2 = NULL,
-					   var_est = TRUE, var_method = var_method,
-					   datatype = "means",
-					   B = 1000)),
-				error=function(err) {
-					message(err, "\n")
-					return(NULL)
-				} )
+  
+  estps <- tryCatch(mase::postStrat(y = y,
+                                    xsample = x_sample,
+                                    xpop = x_pop,
+                                    pi = NULL,
+                                    N = N,
+                                    pi2 = NULL,
+                                    var_est = TRUE,
+                                    var_method = var_method,
+                                    datatype = "means",
+                                    messages = F,
+                                    fpc = !FIA,
+                                    B = 1000),
+                    error=function(err) {
+                      message(err, "\n")
+                      return(NULL)
+                    })
+  
   if (is.null(estps)) {
     if (save4testing) {
       message("saving objects to working directory for testing: y, x_sample, x_pop, N")
-
+      
       save(y, file=file.path(getwd(), "y.rda"))
       save(x_sample, file=file.path(getwd(), "x_sample.rda"))
       save(x_pop, file=file.path(getwd(), "x_pop.rda"))
@@ -67,23 +81,20 @@ MAest.ps <- function(y, N, x_sample, x_pop, FIA=TRUE, save4testing=TRUE, getweig
     estps <- data.table(matrix(c(NA, NA, NBRPLT, NBRPLT.gt0), 1,4))
     setnames(estps, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
     returnlst <- list(est=estps)
-
+    
     if (getweights) {
       weights <- rep(NA, length(y))
       returnlst$weights <- weights
     }
+    
     return(returnlst)
+    
   }
-
+  
   estpsdt <- data.table(estps$pop_mean, estps$pop_mean_var, NBRPLT, NBRPLT.gt0)
   setnames(estpsdt, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
-  returnlst <- list(est=estpsdt)
-
-  if (FIA) {
-    ## This takes out the finite population correction term (to estimated variance from FIA)
-    estpsdt[, nhat.var := nhat.var / (1 - length(y) / N)]
-  }
-
+  returnlst <- list(est = estpsdt)
+  
   ## Return survey weights
   if (getweights) {
     if (any(estps$weights < 0)) {
@@ -91,101 +102,85 @@ MAest.ps <- function(y, N, x_sample, x_pop, FIA=TRUE, save4testing=TRUE, getweig
     }
     returnlst$weights <- estps$weights / N
   }
+  
   return(returnlst)
+  
 }
 
 #' @rdname estimation_desc
 #' @export
-MAest.greg <- function(y, N, x_sample, x_pop, FIA=TRUE, save4testing=TRUE,
-			modelselect=FALSE, getweights=FALSE, var_method = "LinHTSRS") {
-
-  #y <- yn.vect
-
+MAest.greg <- function(y,
+                       N,
+                       x_sample,
+                       x_pop,
+                       FIA = TRUE,
+                       save4testing = TRUE,
+                       getweights = FALSE,
+                       var_method = "LinHTSRS") {
+  
   ## Set global variables
   nhat.var <- NULL
-
   NBRPLT <- length(y)
   NBRPLT.gt0 <- sum(y > 0)
-
-  ## define empty data frame for storing selected predictors
+  
   predselect <- x_pop[FALSE, , drop=FALSE]
-
-  if (modelselect) {
-    ## Get model-selected variables using mase::gregElasticNet()
-    preds.selected <- gregEN.select(y, x_sample, x_pop, N, alpha=0.5)
-  } else {
-    preds.selected <- names(predselect)
-  }
-
-  ## Note: GREG cannot have more predictors than plots
-  if (length(y) <= length(names(predselect))) {
-    preds.selected <- na.omit(preds.selected[1:(length(y)-1)])
-  }
-
-#  if (!is.null(preds.selected) && length(preds.selected) > 0) {
-    if (length(preds.selected) == 0) {
-      xsample <- x_sample[, names(predselect), drop=FALSE]
-      xpop <- x_pop[, names(predselect), drop=FALSE]
-    } else {
-      xsample <- x_sample[, preds.selected, drop=FALSE]
-      xpop <- x_pop[, preds.selected, drop=FALSE]
-    }
-
-    # var_method <- "LinHTSRS"
-    estgreg <- tryCatch(suppressMessages(mase::greg(	y = y,
-					xsample = xsample,
-					xpop = x_pop,
-					pi = NULL, N = N, pi2 = NULL,
-					model = "linear",
-  					var_est = TRUE, var_method = var_method,
-					datatype = "means",
-  					modelselect = FALSE,
-					lambda = "lambda.min",
-					B = 1000)),
-				error=function(err) {
-					message(err, "\n")
-					return(NULL)
-				} )
-#  } else {
-#    estgreg <- NULL
-#  }
+  
+  estgreg <- tryCatch(mase::greg(y = y,
+                                 xsample = x_sample,
+                                 xpop = x_pop,
+                                 pi = NULL,
+                                 N = N,
+                                 pi2 = NULL,
+                                 model = "linear",
+                                 var_est = TRUE,
+                                 var_method = var_method,
+                                 datatype = "means",
+                                 modelselect = FALSE,
+                                 lambda = "lambda.min",
+                                 messages = F,
+                                 fpc = !FIA,
+                                 B = 1000),
+                      error = function(err) {
+                        message(err, "\n")
+                        return(NULL)
+                      } )
+  
   if (is.null(estgreg)) {
+    
     if (save4testing) {
       message("saving objects to working directory for testing: y, x_sample, x_pop, N")
-
+      
       save(y, file=file.path(getwd(), "y.rda"))
       save(x_sample, file=file.path(getwd(), "x_sample.rda"))
       save(x_pop, file=file.path(getwd(), "x_pop.rda"))
       save(N, file=file.path(getwd(), "N.rda"))
     }
+    
     message("multicolinearity exists in predictor data set...  try MAmethod = gregEN")
     estgreg <- data.table(matrix(c(NA, NA, NBRPLT, NBRPLT.gt0), 1,4))
     setnames(estgreg, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
     predselect[1,] <- NA
     returnlst <- list(est=estgreg, predselect=predselect)
-
+    
     if (getweights) {
       weights <- rep(NA, length(y))
       returnlst$weights <- weights
     }
+    
     return(returnlst)
+    
   }
- 
+  
   selected <- data.frame(t(estgreg$coefficients))[,-1]
   if (!is(selected, "data.frame")) {
-    predselect <- rbindlist(list(predselect, as.list(selected)), fill=TRUE)
+    predselect <- rbindlist(list(predselect, as.list(selected)), fill = TRUE)
   } else {  
-    predselect <- rbindlist(list(predselect, selected), fill=TRUE)
+    predselect <- rbindlist(list(predselect, selected), fill = TRUE)
   }
   estgregdt <- data.table(estgreg$pop_mean, estgreg$pop_mean_var, NBRPLT, NBRPLT.gt0)
   setnames(estgregdt, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
-  returnlst <- list(est=estgregdt, predselect=predselect)
-
-  ## This takes out the finite population correction term (to estimated variance from FIA)
-  if (FIA) {
-    estgregdt[, nhat.var := nhat.var / (1 - length(y) / N)]
-  }
-
+  returnlst <- list(est = estgregdt, predselect = predselect)
+  
   ## Return survey weights
   if (getweights) {
     if (any(estgreg$weights < 0)) {
@@ -193,38 +188,46 @@ MAest.greg <- function(y, N, x_sample, x_pop, FIA=TRUE, save4testing=TRUE,
     }
     returnlst$weights <- estgreg$weights / N
   }
+  
   return(returnlst)
+  
 }
 
 #' @rdname estimation_desc
 #' @export
-MAest.ratio <- function(y, N, x_sample, x_pop, FIA=TRUE, save4testing=TRUE,
+MAest.ratio <- function(y,
+                        N,
+                        x_sample,
+                        x_pop,
+                        FIA = TRUE,
+                        save4testing = TRUE,
                         var_method = "LinHTSRS") {
-
-#y <- yn.vect
-
+  
   ## Set global variables
   nhat.var <- NULL
-
   NBRPLT <- length(y)
   NBRPLT.gt0 <- sum(y > 0)
-  # var_method <- "LinHTSRS"
-
-  estratio <- tryCatch(suppressMessages(mase::ratioEstimator(	y = y,
-					xsample = x_sample,
-					xpop = x_pop,
-					pi = NULL, N = N, pi2 = NULL,
-					var_est = TRUE, var_method = var_method,
-					datatype = "means",
-					B = 1000)),
-				error=function(err) {
-					message(err, "\n")
-					return(NULL)
-				} )
+  
+  estratio <- tryCatch(mase::ratioEstimator(y = y,
+                                            xsample = x_sample,
+                                            xpop = x_pop,
+                                            pi = NULL,
+                                            N = N,
+                                            pi2 = NULL,
+                                            var_est = TRUE,
+                                            var_method = var_method,
+                                            datatype = "means",
+                                            messages = F,
+                                            fpc = !FIA,
+                                            B = 1000),
+                       error = function(err) {
+                         message(err, "\n")
+                         return(NULL)
+                       })
   if (is.null(estratio)) {
     if (save4testing) {
       message("saving objects to working directory for testing: y, x_sample, x_pop, N")
-
+      
       save(y, file=file.path(getwd(), "y.rda"))
       save(x_sample, file=file.path(getwd(), "x_sample.rda"))
       save(x_pop, file=file.path(getwd(), "x_pop.rda"))
@@ -233,108 +236,107 @@ MAest.ratio <- function(y, N, x_sample, x_pop, FIA=TRUE, save4testing=TRUE,
     message("error in mase::ratioEstimator function... returning NA")
     estratio <- data.table(matrix(c(NA, NA, NBRPLT, NBRPLT.gt0), 1,4))
     setnames(estratio, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
-    returnlst <- list(est=estratio)
-
-#    if (getweights) {
-#      weights <- rep(NA, length(y))
-#      returnlst$weights <- weights
-#    }
+    returnlst <- list(est = estratio)
+    
     return(returnlst)
+    
   }
-
+  
   estratiodt <- data.table(estratio$pop_mean, estratio$pop_mean_var, NBRPLT, NBRPLT.gt0)
   setnames(estratiodt, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
-  returnlst <- list(est=estratiodt)
-
-  ## This takes out the finite population correction term (to estimated variance from FIA)
-  if (FIA) {
-    estratiodt[, nhat.var := nhat.var / (1 - length(y) / N)]
-  }
+  returnlst <- list(est = estratiodt)
+  
   ## Return survey weights
-#  if (getweights) {
-#    if (any(estratio$weights < 0)) {
-#      message("model resulted in negatives... indicating model instability")
-#    }
-#    returnlst$weights <- estratio$weights / N
-#  }
+  #  if (getweights) {
+  #    if (any(estratio$weights < 0)) {
+  #      message("model resulted in negatives... indicating model instability")
+  #    }
+  #    returnlst$weights <- estratio$weights / N
+  #  }
   return(returnlst)
 }
 
 #' @rdname estimation_desc
 #' @export
-MAest.gregEN <- function(y, N, x_sample, x_pop, FIA=TRUE, model="linear",
-		save4testing=TRUE, getweights=FALSE, var_method = "LinHTSRS") {
-
-#y <- yn.vect
-
+MAest.gregEN <- function(y,
+                         N,
+                         x_sample,
+                         x_pop,
+                         FIA = TRUE,
+                         model = "linear",
+                         save4testing = TRUE,
+                         getweights = FALSE,
+                         var_method = "LinHTSRS") {
+  
   ## define empty data frame for storing selected predictors
   predselect <- x_pop[FALSE, ]
-
-
+  
   ## Set global variables
   nhat.var <- NULL
-
+  
   NBRPLT <- length(y)
   NBRPLT.gt0 <- sum(y > 0)
   # var_method <- "LinHTSRS"
-  estgregEN <- tryCatch(suppressMessages(mase::gregElasticNet(	y = y,
-					xsample = x_sample,
-					xpop = x_pop,
-					pi = NULL, N = N, pi2 = NULL,
-					model = model,
-  					var_est = TRUE, var_method = var_method,
-					datatype = "means",
-					lambda = "lambda.min",
-					B = 1000)),
-				error=function(err) {
-					message(err, "\n")
-					return(NULL)
-				} )
-
+  estgregEN <- tryCatch(mase::gregElasticNet(y = y,
+                                             xsample = x_sample,
+                                             xpop = x_pop,
+                                             pi = NULL,
+                                             N = N,
+                                             pi2 = NULL,
+                                             model = model,
+                                             var_est = TRUE, 
+                                             var_method = var_method,
+                                             datatype = "means",
+                                             lambda = "lambda.min",
+                                             messages = F,
+                                             fpc = !FIA,
+                                             B = 1000),
+                        error = function(err) {
+                          message(err, "\n")
+                          return(NULL)
+                        })
+  
   if (is.null(estgregEN)) {
     if (save4testing) {
       message("saving objects to working directory for testing: y, x_sample, x_pop, N")
-
+      
       save(y, file=file.path(getwd(), "y.rda"))
       save(x_sample, file=file.path(getwd(), "x_sample.rda"))
       save(x_pop, file=file.path(getwd(), "x_pop.rda"))
       save(N, file=file.path(getwd(), "N.rda"))
     }
     message("error in mase::gregElasticNet function... returning NA")
-
+    
     estgregEN <- data.table(matrix(c(NA, NA, NBRPLT, NBRPLT.gt0), 1,4))
     setnames(estgregEN, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
     predselect[1,] <- NA
     returnlst <- list(est=estgregEN, predselect=predselect)
-
-   if (getweights) {
-     weights <- rep(NA, length(y))
-     returnlst$weights <- weights
-   }
+    
+    if (getweights) {
+      weights <- rep(NA, length(y))
+      returnlst$weights <- weights
+    }
     return(returnlst)
   }
-
+  
   selected <- data.frame(t(estgregEN$coefficients))[,-1]
-  predselect <- rbindlist(list(predselect, selected), fill=TRUE)
-
+  predselect <- rbindlist(list(predselect, selected), fill = TRUE)
+  
   estgregENdt <- data.table(estgregEN$pop_mean, estgregEN$pop_mean_var, NBRPLT, NBRPLT.gt0)
   setnames(estgregENdt, c("nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
-
+  
   returnlst <- list(est=estgregENdt, predselect=predselect)
-
-  if (FIA) {
-    ## This takes out the finite population correction term (to estimated variance from FIA)
-    estgregENdt[, nhat.var := nhat.var / (1 - length(y) / N)]
-  }
+  
   ## Return survey weights
- if (getweights) {
-   if (any(estgregEN$weights < 0)) {
-     message("model resulted in negatives... indicating model instability")
-   }
-   returnlst$weights <- estgregEN$weights / N
- }
+  if (getweights) {
+    if (any(estgregEN$weights < 0)) {
+      message("model resulted in negatives... indicating model instability")
+    }
+    returnlst$weights <- estgregEN$weights / N
+  }
+  
   return(returnlst)
-
+  
 }
 
 
@@ -343,12 +345,22 @@ MAest.gregEN <- function(y, N, x_sample, x_pop, FIA=TRUE, model="linear",
 ########################################################################
 #' @rdname estimation_desc
 #' @export
-MAest <- function(yn="CONDPROP_ADJ", dat.dom, cuniqueid, unitlut=NULL,
-	pltassgn, esttype="ACRES", MAmethod, strvar=NULL, prednames=NULL,
-	yd=NULL, ratiotype="PERACRE", N, FIA=TRUE, modelselect=FALSE,
-	getweights=FALSE, 
-	var_method = ifelse(MAmethod %in% c("PS"), "SRSunconditional", "LinHTSRS")) {
-
+MAest <- function(yn = "CONDPROP_ADJ",
+                  dat.dom,
+                  cuniqueid,
+                  unitlut = NULL,
+                  pltassgn,
+                  esttype="ACRES",
+                  MAmethod,
+                  strvar = NULL, 
+                  prednames = NULL,
+                  yd = NULL,
+                  ratiotype = "PERACRE",
+                  N,
+                  FIA = TRUE,
+                  getweights = FALSE, 
+                  var_method = ifelse(MAmethod %in% c("PS"), "SRSunconditional", "LinHTSRS")) {
+  
   ########################################################################################
   ## DESCRIPTION: Gets estimates from mase::horvitzThompson
   ## PARAMETERS:
@@ -365,59 +377,89 @@ MAest <- function(yn="CONDPROP_ADJ", dat.dom, cuniqueid, unitlut=NULL,
   ## dhat.var	- variance of estimated proportion, for denominator
   ## covar		- covariance of numerator and denominator
   ########################################################################################
-
+  
   ## Merge dat.dom to pltassgn
   pltdat.dom <- as.data.frame(dat.dom[pltassgn])
   pltdat.dom[is.na(pltdat.dom[[yn]]), yn] <- 0
-
+  
   ## Subset response vector and change NA values of response to 0
   yn.vect <- pltdat.dom[[yn]]
-
+  
   if (MAmethod == "HT") {
-    estlst <- MAest.ht(yn.vect, N, FIA=FIA,
-			getweights=getweights, var_method = var_method)
-
+    
+    estlst <- MAest.ht(yn.vect,
+                       N,
+                       FIA = FIA,
+                       getweights = getweights,
+                       var_method = var_method)
+    
   } else if (MAmethod == "PS") {
+    
     x_sample <- pltdat.dom[, strvar][[1]]
     x_pop <- unitlut[, c(strvar, "Prop"), with=FALSE]
-
-    estlst <- MAest.ps(yn.vect, N, x_sample, x_pop, FIA=FIA,
-			getweights=getweights, var_method = var_method)
-
+    
+    estlst <- MAest.ps(yn.vect,
+                       N, 
+                       x_sample,
+                       x_pop,
+                       FIA = FIA,
+                       getweights = getweights,
+                       var_method = var_method)
+    
   } else {
-
+    
     x_sample <- setDF(pltdat.dom)[, prednames, drop=FALSE]
     x_pop <- setDF(unitlut)[, prednames, drop=FALSE]
-
+    
     if (MAmethod == "greg") {
-      estlst <- MAest.greg(yn.vect, N, x_sample, x_pop, FIA=FIA,
-		modelselect=modelselect, getweights=getweights, var_method = var_method)
-
+      
+      estlst <- MAest.greg(yn.vect,
+                           N,
+                           x_sample,
+                           x_pop,
+                           FIA = FIA,
+                           getweights = getweights,
+                           var_method = var_method)
+      
     } else if (MAmethod == "gregEN") {
-      estlst <- MAest.gregEN(yn.vect, N, x_sample, x_pop, FIA=FIA,
-                             getweights=getweights, var_method = var_method)
-
+      
+      estlst <- MAest.gregEN(yn.vect,
+                             N,
+                             x_sample,
+                             x_pop,
+                             FIA = FIA,
+                             getweights = getweights,
+                             var_method = var_method)
+      
     } else if (MAmethod == "ratio") {
+      
       if (length(prednames) > 1) {
         stop("only one continuous predictor is allowed")
       } else {
         x_sample <- x_sample[[prednames]]
         x_pop <- x_pop[[prednames]]
       }
-      est <- MAest.ratio(yn.vect, N, x_sample, x_pop, FIA=FIA, 
+      
+      est <- MAest.ratio(yn.vect,
+                         N,
+                         x_sample,
+                         x_pop,
+                         FIA = FIA, 
                          var_method = var_method)
-
+      
     } else {
       stop("invalid MAmethod")
     }
+    
   }
-
+  
   if (getweights) {
     estlst$weights <- data.frame(pltdat.dom[[cuniqueid]], estlst$weights)
     names(estlst$weights) <- c(cuniqueid, "weights")
   }
-
+  
   return(estlst)
+  
 }
 
 
@@ -426,44 +468,59 @@ MAest <- function(yn="CONDPROP_ADJ", dat.dom, cuniqueid, unitlut=NULL,
 ########################################################################
 #' @rdname estimation_desc
 #' @export
-MAest.dom <- function(dom, dat, cuniqueid, unitlut, pltassgn, esttype, MAmethod,
-		strvar=NULL, prednames=NULL, domain, N, response=NULL, FIA=TRUE,
-		modelselect=FALSE, getweights=FALSE,
-		var_method = ifelse(MAmethod %in% c("PS"), "SRSunconditional", "LinHTSRS")) {
-
+MAest.dom <- function(dom,
+                      dat,
+                      cuniqueid,
+                      unitlut,
+                      pltassgn,
+                      esttype,
+                      MAmethod,
+                      strvar = NULL,
+                      prednames = NULL,
+                      domain,
+                      N,
+                      response = NULL,
+                      FIA = TRUE,
+                      getweights = FALSE,
+                      var_method = ifelse(MAmethod %in% c("PS"), "SRSunconditional", "LinHTSRS")) {
+  
   ## Subset tomdat to domain=dom
   dat.dom <- dat[dat[[domain]] == dom,]
-
+  
   if (nrow(dat.dom) == 0 || sum(!is.na(dat.dom[[domain]])) == 0) {
+    
     domest <- data.table(dom, matrix(c(NA, NA, 0, 0), 1,4))
     setnames(domest, c(domain, "nhat", "nhat.var", "NBRPLT", "NBRPLT.gt0"))
-
-    predselect <- data.table(dom, unitlut[FALSE,
-				unique(c(prednames, strvar), with=FALSE)])
+    
+    predselect <- data.table(dom, unitlut[FALSE, unique(c(prednames, strvar), with=FALSE)])
     setnames(predselect, "dom", domain)
     returnlst <- list(est=domest, predselect=predselect)
+    
     if (getweights) {
       weights <- data.frame(dom, id=cuniqueid, weights=NA)
       setnames(weights, "id", cuniqueid)
       setnames(weights, "dom", domain)
       returnlst$weights <- weights
     }
+    
     return(returnlst)
+    
   }
-
-#yn=response
-
+  
+  
   ## Apply function to each dom
-  domestlst <- MAest(yn=response, dat.dom=dat.dom, pltassgn=pltassgn,
-		cuniqueid=cuniqueid, esttype=esttype, unitlut=unitlut,
-		strvar=strvar, prednames=prednames,
-		MAmethod=MAmethod, N=N, FIA=FIA, modelselect=modelselect,
-		getweights=getweights, var_method = var_method)
-
+  domestlst <- MAest(yn = response, dat.dom = dat.dom, pltassgn = pltassgn,
+                     cuniqueid = cuniqueid, esttype = esttype, unitlut = unitlut,
+                     strvar = strvar, prednames = prednames, MAmethod = MAmethod,
+                     N = N, FIA = FIA, getweights = getweights, var_method = var_method)
+  
   domestlst <- lapply(domestlst, function(x, dom, domain) {
-		dt <- data.table(dom, x)
-           setnames(dt, "dom", domain) }, dom, domain)
+    dt <- data.table(dom, x)
+    setnames(dt, "dom", domain) 
+  }, dom, domain)
+  
   return(domestlst)
+  
 }
 
 
@@ -473,90 +530,83 @@ MAest.dom <- function(dom, dat, cuniqueid, unitlut, pltassgn, esttype, MAmethod,
 ########################################################################
 #' @rdname estimation_desc
 #' @export
-MAest.unit <- function(unit, dat, cuniqueid, unitlut, unitvar,
-		esttype, MAmethod="HT", strvar=NULL, prednames=NULL,
-		domain, response, npixels, FIA=TRUE, modelselect=TRUE,
-		getweights=FALSE,
-		var_method = ifelse(MAmethod %in% c("PS"), "SRSunconditional", "LinHTSRS")) {
-## testing
-#unit = estunits[1]
-#domain="TOTAL"
- 
-  dat.unit <- dat[dat[[unitvar]] == unit, c(cuniqueid, domain, response),
-			with=FALSE]
+MAest.unit <- function(unit,
+                       dat,
+                       cuniqueid,
+                       unitlut,
+                       unitvar,
+                       esttype,
+                       MAmethod = "HT",
+                       strvar = NULL,
+                       prednames = NULL,
+                       domain,
+                       response,
+                       npixels,
+                       FIA = TRUE,
+                       getweights = FALSE,
+                       var_method = ifelse(MAmethod %in% c("PS"), "SRSunconditional", "LinHTSRS")) {
+  
+  dat.unit <- dat[dat[[unitvar]] == unit, c(cuniqueid, domain, response), with=FALSE]
+  
   if (nrow(dat.unit) == 0 || sum(!is.na(dat.unit[[domain]])) == 0) {
+    
     if (domain == "TOTAL") {
-      unitest <- data.table(unit=unit, domain=1, nhat=0, nhat.var=0,
-		NBRPLT=0, NBRPLT.gt0=0)
+      unitest <- data.table(unit = unit, domain = 1, nhat = 0, nhat.var = 0, NBRPLT = 0, NBRPLT.gt0 = 0)
     } else {
-      unitest <- data.table(unit=unit, domain="TOTAL", nhat=0, nhat.var=0,
-		NBRPLT=0, NBRPLT.gt0=0)
+      unitest <- data.table(unit = unit, domain = "TOTAL", nhat = 0, nhat.var = 0, NBRPLT = 0, NBRPLT.gt0 = 0)
     }
+    
     setnames(unitest, c("unit", "domain"), c(unitvar, domain))
-
-    predselect <- data.table(unit=unit, domain=1,
-				unitlut[FALSE, c(prednames,strvar), with=FALSE])
+    
+    predselect <- data.table(unit = unit, domain = 1, unitlut[FALSE, c(prednames,strvar), with = FALSE])
     setnames(predselect, c("unit", "domain"), c(unitvar, domain))
-    returnlst <- list(unitest=unitest, predselect=predselect)
-
+    returnlst <- list(unitest = unitest, predselect = predselect)
+    
     if (getweights) {
-      weights <- data.frame(unit=unit, domain=1, id=cuniqueid, weights=NA)
+      weights <- data.frame(unit = unit, domain = 1, id = cuniqueid, weights = NA)
       setnames(weights, "id", cuniqueid)
       returnlst$weights <- weights
     }
+    
     return(returnlst)
+    
   }
+  
   setkeyv(dat.unit, cuniqueid)
-  pltassgn.unit <- unique(dat[dat[[unitvar]] == unit, c(cuniqueid, strvar, prednames),
-			with=FALSE])
+  pltassgn.unit <- unique(dat[dat[[unitvar]] == unit, c(cuniqueid, strvar, prednames), with = FALSE])
   setkeyv(pltassgn.unit, cuniqueid)
-
+  
   unitlut.unit <- unitlut[unitlut[[unitvar]] == unit, ]
   N.unit <-  npixels[["npixels"]][npixels[[unitvar]] == unit]
-
-#  if (!MAmethod %in% c("HT", "PS")) {
-#    if (any(pltassgn.unit[, colSums(.SD), .SDcols=prednames] < 3)) {
-#      prednames <- prednames[pltassgn.unit[, colSums(.SD), .SDcols=prednames] >= 3]
-#      if (length(prednames) == 0) MAmethod <- "HT"
-#    }
-#  }
-
-  #doms <- as.character(unique(dat.unit[[domain]]))
+  
   doms <- unique(dat.unit[!is.na(get(domain)) & get(domain) != "NA NA"][[domain]])
-
-#dat=dat.unit
-#unitlut=unitlut.unit
-#pltassgn=pltassgn.unit
-#N=N.unit
-#dom=doms[5]
-
-  unitestlst <- lapply(doms, MAest.dom,
-			dat=dat.unit, cuniqueid=cuniqueid,
-			unitlut=unitlut.unit, pltassgn=pltassgn.unit,
-			esttype=esttype, MAmethod=MAmethod,
-			strvar=strvar, prednames=prednames,
-			domain=domain, N=N.unit, response=response,
-			FIA=FIA, modelselect=modelselect, getweights=getweights,
-			var_method = var_method)
-
+  
+  unitestlst <- lapply(doms, MAest.dom, dat = dat.unit, 
+                       cuniqueid = cuniqueid, unitlut = unitlut.unit,
+                       pltassgn = pltassgn.unit, esttype = esttype,
+                       MAmethod = MAmethod, strvar = strvar, prednames = prednames,
+                       domain = domain, N = N.unit, response = response,
+                       FIA = FIA, getweights = getweights, var_method = var_method)
+  
   unitest <- data.table(unit=unit, do.call(rbind, sapply(unitestlst, '[', "est")))
   setnames(unitest, "unit", unitvar)
-
+  
   returnlst <- list(unitest=unitest)
-
+  
   if (getweights) {
     weights <- data.table(unit=unit, do.call(rbind, sapply(unitestlst, '[', "weights")))
     setnames(weights, "unit", unitvar)
     returnlst$weights <- weights
   }
-
+  
   if (MAmethod %in% c("greg", "gregEN")) {
     predselect <- data.table(unit=unit, do.call(rbind, sapply(unitestlst, '[', "predselect")))
     setnames(predselect, "unit", unitvar)
     returnlst$predselect <- predselect
   }
-
+  
   return(returnlst)
+  
 }
 
 

--- a/R/MAest.pbar.R
+++ b/R/MAest.pbar.R
@@ -127,7 +127,8 @@ MAest.greg <- function(y,
   # and when estimating on a subset of sample data we have fewer plots than predictors...
   if (length(y) <= ncol(x_sample)) {
     x_sample <- x_sample[ , 1:(length(y) - 1), drop = F]
-    x_pop <- x_pop[ , names(x_sample), drop = F]
+    x_pop <- x_pop[ , names(x_sample), with = F, drop = F]
+    warning("There are fewer plots than predictors, predictors will be removed by order of highest index position in xsample until the model can be fit. \n")
   }
   
   predselect <- x_pop[FALSE, , drop=FALSE]

--- a/R/MAest.pbar.R
+++ b/R/MAest.pbar.R
@@ -130,6 +130,7 @@ MAest.greg <- function(y,
     x_pop <- x_pop[ , names(x_sample), drop = F]
   }
   
+  predselect <- x_pop[FALSE, , drop=FALSE]
   
   estgreg <- tryCatch(mase::greg(y = y,
                                  xsample = x_sample,

--- a/man/estimation_desc.Rd
+++ b/man/estimation_desc.Rd
@@ -54,7 +54,6 @@ MAest.greg(
   x_pop,
   FIA = TRUE,
   save4testing = TRUE,
-  modelselect = FALSE,
   getweights = FALSE,
   var_method = "LinHTSRS"
 )
@@ -95,7 +94,6 @@ MAest(
   ratiotype = "PERACRE",
   N,
   FIA = TRUE,
-  modelselect = FALSE,
   getweights = FALSE,
   var_method = ifelse(MAmethod \%in\% c("PS"), "SRSunconditional", "LinHTSRS")
 )
@@ -114,7 +112,6 @@ MAest.dom(
   N,
   response = NULL,
   FIA = TRUE,
-  modelselect = FALSE,
   getweights = FALSE,
   var_method = ifelse(MAmethod \%in\% c("PS"), "SRSunconditional", "LinHTSRS")
 )
@@ -133,7 +130,6 @@ MAest.unit(
   response,
   npixels,
   FIA = TRUE,
-  modelselect = TRUE,
   getweights = FALSE,
   var_method = ifelse(MAmethod \%in\% c("PS"), "SRSunconditional", "LinHTSRS")
 )


### PR DESCRIPTION
more notes about this PR:
- also removing modelselect from this level of the MA module (will now be done in FIESTA/modMAtree.R via the prednames argument i.e the model selection will just be reflected through a modification of the prednames argument).
- the FIA argument in FIESTAutils indicates that the finite population correction term should be removed, thus I think we feed this information into mase as `fpc = !FIA`
- did some general code cleaning and restructuring 