### PR TITLE
avoid GDALRaster class constructor that requires gdalraster v1.8.0

### DIFF
--- a/R/raster_analysis.R
+++ b/R/raster_analysis.R
@@ -1094,7 +1094,7 @@ zonalStats <- function(dsn=NULL, layer=NULL, src=NULL, attribute,
                        na.rm=TRUE, ignoreValue=NULL) {
     ## zoneid, npixels, mean, min, max, sum, var, sd
 
-    ds <- new(GDALRaster, rasterfile)
+    ds <- new(GDALRaster, rasterfile, read_only = TRUE)
     nrows <- ds$getRasterYSize()
     ncols <- ds$getRasterXSize()
     gt <- ds$getGeoTransform()


### PR DESCRIPTION
This PR affects the `zonalStats()` internal function.  It was using a form of the `GDALRaster` class constructor that was added in gdalraster 1.8.0, introducing a version dependence. This PR changes back to original form of the class constructor to avoid the version dependence.