### PR TITLE
update getfilter

### DIFF
--- a/R/cool_functions.R
+++ b/R/cool_functions.R
@@ -491,18 +491,41 @@ nbrdigits <- function(x) {
 
 #' @rdname internal_desc
 #' @export
-getfilter <- function(att, val, syntax="R") {
-## DESCRIPTION: create filter string from att and val
-## syntax - ('R', 'sql')
-  if (is.character(val)) {
-    val <- encodeString(val, quote="'")
+getfilter <- function(att, val, syntax = "R", like = FALSE) {
+  ## DESCRIPTION: create filter string from att and val
+  ## syntax - ('R', 'sql')
+  
+  if (!syntax %in% c("R", "sql")) {
+    stop("Invalid syntax. Must be either 'R' or 'sql'")
   }
-  filter <- paste0(att, " %in% c(", toString(val), ")")
-
-  if (syntax == 'sql') {
-    filter <- gsub("%in% c", "in", filter)
+  
+  if (like) {
+    
+    if (!is.character(val)) {
+      stop("'like' functionality only works with vals(s) of type character")
+    }
+    if (syntax == "R") {
+      valstr <- encodeString(paste0(val, collapse = "|"), quote = "'")
+      filt <- paste0("grepl(", valstr, ", ", att, ")")
+    } else {
+      filt <- paste0(att, " LIKE ", "'%", val, "%'", collapse = " OR ")
+    }
+    
+  } else {
+    
+    if (is.character(val)) {
+      val <- encodeString(val, quote = "'")
+    }
+    filt <- paste0(att, " %in% c(", toString(val), ")")
+    
+    if (syntax == 'sql') {
+      filt <- gsub("%in% c", "in", filt)
+    }
+    
   }
-  return(filter)
+  
+  return(filt)
+  
 }
 
 #' @rdname internal_desc


### PR DESCRIPTION
Adds 'like' argument to `getfilter()` which creates a filter that checks whether the values in an attribute contain a character string. Useful for filtering for ecosubsections when you only know the province. Defaults to FALSE and is added at the end of the function parameters so it does not disrupt any existing code.

``` r
ecomap <- sf::st_drop_geometry(FIESTAnalysis::ecomap)
```
## R syntax test
``` r
xfilter <- getfilter("SUBSECTION", c("M332", "334"), syntax = "R", like = TRUE)
xfilter
#> [1] "grepl('M332|334', SUBSECTION)"

subset(ecomap, eval(parse(text = xfilter))) |> head(10)
#>    SECTION SUBSECTION PROVINCE
#> 68   M332B     M332Bb     M332
#> 69   M332B     M332Bl     M332
#> 72   M332B     M332Bp     M332
#> 74   M332B     M332Bh     M332
#> 82   M332B     M332Bg     M332
#> 84   M332G     M332Gd     M332
#> 85   M332G     M332Gc     M332
#> 86   M332D     M332De     M332
#> 87   M332B     M332Bf     M332
#> 88   M332D     M332Df     M332
```

## sql syntax test

``` r
xfilter <- getfilter("SUBSECTION", c("M332", "334"), syntax = "sql", like = TRUE)
xfilter
#> [1] "SUBSECTION LIKE '%M332%' OR SUBSECTION LIKE '%334%'"

qry <- paste0("SELECT *",
              "\nFROM ecomap",
              "\nWHERE ", xfilter,
              "\nLIMIT 10;")
sqldf::sqldf(qry)
#>    SECTION SUBSECTION PROVINCE
#> 1    M332B     M332Bb     M332
#> 2    M332B     M332Bl     M332
#> 3    M332B     M332Bp     M332
#> 4    M332B     M332Bh     M332
#> 5    M332B     M332Bg     M332
#> 6    M332G     M332Gd     M332
#> 7    M332G     M332Gc     M332
#> 8    M332D     M332De     M332
#> 9    M332B     M332Bf     M332
#> 10   M332D     M332Df     M332
```
