### PR TITLE
extractPtsFromRaster(): fix indexing of output vector when windowsize > 1

### DIFF
--- a/R/raster_analysis.R
+++ b/R/raster_analysis.R
@@ -378,7 +378,7 @@ extractPtsFromRaster <- function(ptdata, rasterfile, band=NULL, var.name=NULL,
         if (windowsize > 1 && is.null(statistic)) {
             # raw pixel values from a window, values as an array
             for (p in 1:(windowsize*windowsize)) {
-                df.out[paste0(this.name,"_",p)] <- values[p,]
+                df.out[paste0(this.name,"_",p)] <- values[p]
             }
         }
         else {


### PR DESCRIPTION
fix needed for https://github.com/USDAForestService/FIESTA/issues/43 (relic from pre-gdalraster), but there is some other issue there as well. All the input points in the reprex appear to be outside the raster extent?