### PR TITLE
extractPtsFromRaster(): fix indexing of output array with windowsize > 1 (supercedes #37)

### DIFF
--- a/R/DBinternal.R
+++ b/R/DBinternal.R
@@ -1636,7 +1636,7 @@ createidx <- function(dbconn, schema=NULL,
     ## get list of tables from database
     dbtablesdf <- as.data.frame(do.call(rbind, 
                       lapply(DBI::dbListObjects(dbconn, DBI::Id(schema = 'wo_fiesta'))$table, 
-                             function(x) slot(x, 'name'))))
+                             function(x) methods::slot(x, 'name'))))
     dbtables <- dbtablesdf$table
   } else {
     

--- a/R/raster_analysis.R
+++ b/R/raster_analysis.R
@@ -172,11 +172,11 @@ getPixelValue <- function(pt, ds, ri=NULL, band=1, interpolate=FALSE,
     #check that point is inside extent rectangle
     if (ptX > xmax || ptX < xmin) {
         warning("point X value is outside raster extent", call.=FALSE)
-        return(NA)
+        return(rep(NA, windowsize * windowsize))
     }
     if (ptY > ymax || ptY < ymin) {
         warning("point Y value is outside raster extent", call.=FALSE)
-        return(NA)
+        return(rep(NA, windowsize * windowsize))
     }
 
     #get pixel offsets
@@ -200,7 +200,11 @@ getPixelValue <- function(pt, ds, ri=NULL, band=1, interpolate=FALSE,
                 offY < 0 || (offY+windowsize-1) > nrows) {
             warning("window is not completely within raster extent",
                     call.=FALSE)
-            return(NA)
+            if (is.null(statistic) && windowsize > 1) {
+                return(rep(NA, windowsize * windowsize))
+            } else {
+                return(NA)
+            }
         }
     }
 

--- a/R/table_functions.R
+++ b/R/table_functions.R
@@ -490,7 +490,8 @@ crossxtab <- function (group.est, rowvar.est=NULL, colvar.est=NULL, total.est=NU
   #################################################################################
   dcastdrop <- TRUE
   if (is.factor(rowvar.est[[rowvar]])) {
-    if (any(is.na(levels(rowvar.est[[rowvar]])))) {
+    #if (any(as.character(levels(rowvar.est[[rowvar]])) == "NA")) {
+    if (length(levels(rowvar.est[[rowvar]])) > length(rowvar.est[[rowvar]])) {
       dcastdrop <- FALSE
     }
   } else {
@@ -499,7 +500,8 @@ crossxtab <- function (group.est, rowvar.est=NULL, colvar.est=NULL, total.est=NU
     }
   }
   if (is.factor(colvar.est[[colvar]])) {
-    if (any(is.na(levels(colvar.est[[colvar]])))) {
+    #if (any(as.character(levels(colvar.est[[colvar]])) == "NA")) {
+    if (length(levels(colvar.est[[colvar]])) > length(colvar.est[[colvar]])) {
       dcastdrop <- FALSE
     }
   } else {


### PR DESCRIPTION
supercedes https://github.com/USDAForestService/FIESTAutils/pull/37: the problem was with `NA` handling with `windowsize > 1`, specifically returning a vector of `NA` of length `windowsize * windowsize` when there are no valid pixel values, so that the array resulting from `apply()` has the correct dimensions in the end.