### PR TITLE
fix indexing of output vector

### DIFF
--- a/R/raster_analysis.R
+++ b/R/raster_analysis.R
@@ -172,7 +172,7 @@ getPixelValue <- function(pt, ds, ri=NULL, band=1, interpolate=FALSE,
     #check that point is inside extent rectangle
     if (ptX > xmax || ptX < xmin) {
         warning("point X value is outside raster extent", call.=FALSE)
-        if (statistic == "value") {
+        if (windowsize > 1 && is.null(statistic)) {
           return(rep(NA, windowsize * windowsize))
         } else {
           return(NA)
@@ -180,7 +180,7 @@ getPixelValue <- function(pt, ds, ri=NULL, band=1, interpolate=FALSE,
     }
     if (ptY > ymax || ptY < ymin) {
         warning("point Y value is outside raster extent", call.=FALSE)
-        if (statistic == "value") {
+        if (windowsize > 1 && is.null(statistic)) {
           return(rep(NA, windowsize * windowsize))
         } else {
           return(NA)

--- a/R/raster_analysis.R
+++ b/R/raster_analysis.R
@@ -172,11 +172,19 @@ getPixelValue <- function(pt, ds, ri=NULL, band=1, interpolate=FALSE,
     #check that point is inside extent rectangle
     if (ptX > xmax || ptX < xmin) {
         warning("point X value is outside raster extent", call.=FALSE)
-        return(rep(NA, windowsize * windowsize))
+        if (statistic == "value") {
+          return(rep(NA, windowsize * windowsize))
+        } else {
+          return(NA)
+        }
     }
     if (ptY > ymax || ptY < ymin) {
         warning("point Y value is outside raster extent", call.=FALSE)
-        return(rep(NA, windowsize * windowsize))
+        if (statistic == "value") {
+          return(rep(NA, windowsize * windowsize))
+        } else {
+          return(NA)
+        }
     }
 
     #get pixel offsets


### PR DESCRIPTION
@ctoney I think we only want a vector of NAs when windowsize > 1 and windowstat = "value", otherwise we still want just a single NA value if the windowstat aggregates the values.